### PR TITLE
Изменение алгоритма создания, хранения, взаимодействия и удаления подстратегий

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,20 +1,44 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <limits.h>
+#include <string.h>
 #include "print.h"
 #include "binary.h"
 #include "strategy.h"
 
-uint_fast32_t MEMORY_DEPTH = 2;
-const uint_fast32_t ITERATIONS_COUNT = 100;
+uint_fast32_t MEMORY_DEPTH = 1;
+uint_fast32_t ITERATIONS_COUNT = 100;
 int_fast32_t MATRIX[2][2] = {
     {1, 5},
     {0, 3}
 };
 
-int main() {
+void init_global_params(int argc, char** argv){
+    for (int i = 0; i < argc; i++){
+        if(strcmp(argv[i], "-h") == 0){
+            println("Options:");
+            println("\t-h                                      Print help (this message)");
+            println("\t-i <number>                             Set iterations count for every two strategies");
+            println("\t-d <number>                             Set strategy memory depth");
+            println("\t-m <number> <number> <number> <number>  Set reward matrix for strategies");
+            exit(0);
+        } else if(strcmp(argv[i], "-i") == 0 && (i + 1) < argc){
+            ITERATIONS_COUNT = atoi(argv[++i]);
+        } else if(strcmp(argv[i], "-d") == 0 && (i + 1) < argc){
+            MEMORY_DEPTH = atoi(argv[++i]);
+        } else if(strcmp(argv[i], "-m") == 0 && (i + 4) < argc){
+            MATRIX[0][0] = atoi(argv[++i]);
+            MATRIX[0][1] = atoi(argv[++i]);
+            MATRIX[1][0] = atoi(argv[++i]);
+            MATRIX[1][1] = atoi(argv[++i]);
+        }
+    }
+}
+
+int main(int argc, char** argv) {
+    init_global_params(argc, argv);
+
     Strategy_data data = *create_Strategy_data(MEMORY_DEPTH, ITERATIONS_COUNT, MATRIX);
-    //play(&data, 26636, 23771);
 
     while(data.all_strategies_count >= 2 * data.sub_strategies_count) {
         for (int_fast32_t i = 0; i < data.all_strategies_count; i++) {

--- a/main.c
+++ b/main.c
@@ -5,8 +5,8 @@
 #include "binary.h"
 #include "strategy.h"
 
-uint_fast32_t MEMORY_DEPTH = 0;
-const uint_fast32_t ITERATIONS_COUNT = 500;
+uint_fast32_t MEMORY_DEPTH = 2;
+const uint_fast32_t ITERATIONS_COUNT = 100;
 int_fast32_t MATRIX[2][2] = {
     {1, 5},
     {0, 3}
@@ -14,28 +14,22 @@ int_fast32_t MATRIX[2][2] = {
 
 int main() {
     Strategy_data data = *create_Strategy_data(MEMORY_DEPTH, ITERATIONS_COUNT, MATRIX);
-//    for (int i = 0; i < data.all_strategies_count; i++){
-//        printf("%d: ", i);
-//        println_strategy(&data, i);
-//    }
-
     //play(&data, 26636, 23771);
 
-    //while(data.all_strategies_count > 2) {
+    while(data.all_strategies_count >= 2 * data.sub_strategies_count) {
         for (int_fast32_t i = 0; i < data.all_strategies_count; i++) {
             for (int_fast32_t j = i; j < data.all_strategies_count; j++) {
                 play(&data, i, j);
             }
         }
 
-        for (int_fast32_t i = 0; i < data.all_strategies_count; i++) {
-            println_strategy(&data, i);
-        }
-        println("\n");
-
-        //remove_strategies(&data);
+        print_all_strategies(&data);
+        average_strategies(&data);
+        print_main_strategies(&data);
+        remove_strategies(&data);
+        printf("%d/%d\n", data.all_strategies_count, 2 * data.sub_strategies_count);
         println("----------------------------------");
-    //}
+    }
 
     delete_Strategy_data(&data);
 }

--- a/main.c
+++ b/main.c
@@ -18,19 +18,8 @@ int main() {
 //        printf("%d: ", i);
 //        println_strategy(&data, i);
 //    }
-//    println_strategy(&data, 26636);
-//    println_strategy(&data, 23771);
 
     //play(&data, 26636, 23771);
-
-    uint_fast32_t* arr = init_complexity_array(data.all_strategies_count);
-
-    for (int_fast32_t i = 0; i < data.all_strategies_count; i+= data.sub_strategies_count) {
-        printf("%d : %d\n", data.strategies[i].name, get_complexity(data.strategies[i].name, arr, data.main_digits_count));
-    }
-
-    free(arr);
-    printf("\n");
 
     //while(data.all_strategies_count > 2) {
         for (int_fast32_t i = 0; i < data.all_strategies_count; i++) {

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 #include "strategy.h"
 
 uint_fast32_t MEMORY_DEPTH = 0;
-const uint_fast32_t ITERATIONS_COUNT = 100;
+const uint_fast32_t ITERATIONS_COUNT = 500;
 int_fast32_t MATRIX[2][2] = {
     {1, 5},
     {0, 3}
@@ -14,6 +14,14 @@ int_fast32_t MATRIX[2][2] = {
 
 int main() {
     Strategy_data data = *create_Strategy_data(MEMORY_DEPTH, ITERATIONS_COUNT, MATRIX);
+//    for (int i = 0; i < data.all_strategies_count; i++){
+//        printf("%d: ", i);
+//        println_strategy(&data, i);
+//    }
+//    println_strategy(&data, 26636);
+//    println_strategy(&data, 23771);
+
+    //play(&data, 26636, 23771);
 
     uint_fast32_t* arr = init_complexity_array(data.all_strategies_count);
 
@@ -24,7 +32,7 @@ int main() {
     free(arr);
     printf("\n");
 
-    while(data.all_strategies_count > 2) {
+    //while(data.all_strategies_count > 2) {
         for (int_fast32_t i = 0; i < data.all_strategies_count; i++) {
             for (int_fast32_t j = i; j < data.all_strategies_count; j++) {
                 play(&data, i, j);
@@ -36,9 +44,9 @@ int main() {
         }
         println("\n");
 
-        remove_strategies(&data);
+        //remove_strategies(&data);
         println("----------------------------------");
-    }
+    //}
 
     delete_Strategy_data(&data);
 }

--- a/memory.h
+++ b/memory.h
@@ -1,0 +1,17 @@
+#ifndef MEMORY_H_INCLUDED
+#define MEMORY_H_INCLUDED
+
+/**
+* Macro that allocates memory for given count of elements of needed type.
+* Example of usage:
+* int var = *new(int, 1);
+* int* ptr = new(int, 1);
+* int* array = new(int, size);
+* @param type - type of object(s) to be allocated
+* @param count - count of elements to be allocated
+* @return pointer to allocated memory. For example, if needed type was
+*         int, return type will be int*
+*/
+#define new(type, count) ((type*) malloc(sizeof(type) * count))
+
+#endif // MEMORY_H_INCLUDED

--- a/print.c
+++ b/print.c
@@ -12,7 +12,7 @@ void println_binary(int_fast32_t x, int_fast32_t digits) {
 }
 
 void print_strategy(Strategy_data* data, int_fast32_t index) {
-    for (int i = 0; i < data->memory_depth + 1; i++){
+    for (int i = 0; i < data->memory_depth + 1; i++) {
         print("[");
         print_binary(data->strategies[index].sub_strategies / power(i), power(i));
         print("]");
@@ -25,3 +25,19 @@ void println_strategy(Strategy_data* data, int_fast32_t index) {
     print_strategy(data, index);
     printf("\n");
 }
+
+void print_all_strategies(Strategy_data* data) {
+    for (int_fast32_t i = 0; i < data->all_strategies_count; i++) {
+        println_strategy(data, i);
+    }
+    println("\n");
+}
+
+void print_main_strategies(Strategy_data* data) {
+    for (int_fast32_t i = 0; i < data->all_strategies_count; i += data->sub_strategies_count) {
+        print_binary(data->strategies[i].name, data->main_digits_count);
+        printf(" (%u)\t%lu\n", data->strategies[i].complexity, data->strategies[i].points);
+    }
+    println("\n");
+}
+

--- a/print.c
+++ b/print.c
@@ -18,7 +18,7 @@ void print_strategy(Strategy_data* data, int_fast32_t index) {
         print("]");
     }
     print_binary(data->strategies[index].name, data->main_digits_count);
-    printf("\t%u", data->strategies[index].points);
+    printf(" (%u)\t%lu", data->strategies[index].complexity, data->strategies[index].points);
 }
 
 void println_strategy(Strategy_data* data, int_fast32_t index) {

--- a/print.c
+++ b/print.c
@@ -12,11 +12,13 @@ void println_binary(int_fast32_t x, int_fast32_t digits) {
 }
 
 void print_strategy(Strategy_data* data, int_fast32_t index) {
-    print("[");
-    print_binary(data->strategies[index].first_move, data->main_digits_count / 2);
-    print("]");
+    for (int i = 0; i < data->memory_depth + 1; i++){
+        print("[");
+        print_binary(data->strategies[index].sub_strategies / power(i), power(i));
+        print("]");
+    }
     print_binary(data->strategies[index].name, data->main_digits_count);
-    printf("\t%d", data->strategies[index].points);
+    printf("\t%u", data->strategies[index].points);
 }
 
 void println_strategy(Strategy_data* data, int_fast32_t index) {

--- a/print.h
+++ b/print.h
@@ -38,7 +38,7 @@ void println_binary(int_fast32_t x, int_fast32_t digits);
 
 /**
 * Function for printing the strategy object in readable form
-* form without line separator.
+* without line separator.
 * @param data - pointer for Strategy_data with needed strategies and parameters
 * @param index - index of strategy to be printed
 */
@@ -46,10 +46,22 @@ void print_strategy(Strategy_data* data, int_fast32_t index);
 
 /**
 * Function for printing the strategy object in readable form
-* form with line separator.
+* with line separator.
 * @param data - pointer for Strategy_data with needed strategies and parameters
 * @param index - index of strategy to be printed
 */
 void println_strategy(Strategy_data* data, int_fast32_t index);
+
+/**
+* Function for printing all strategies from Strategy_data object in readable form
+* @param data - pointer for Strategy_data with needed strategies and parameters
+*/
+void print_all_strategies(Strategy_data* data);
+
+/**
+* Function for printing main strategies of every family from Strategy_data object in readable form
+* @param data - pointer for Strategy_data with needed strategies and parameters
+*/
+void print_main_strategies(Strategy_data* data);
 
 #endif // PRINT_H_INCLUDED

--- a/strategy.c
+++ b/strategy.c
@@ -117,7 +117,7 @@ void remove_strategies(Strategy_data* this) {
 
 void delete_Strategy_data(Strategy_data* this) {
     free(this->strategies);
-    free(this);
+    //free(this);
 }
 
 uint_fast32_t* init_complexity_array(int_fast32_t strategy_count){

--- a/strategy.c
+++ b/strategy.c
@@ -84,26 +84,25 @@ void play(Strategy_data* this, int_fast32_t i, int_fast32_t j) {
     }
 }
 
+void average_strategies(Strategy_data* this){
+    for (int_fast32_t i = 0; i < this->all_strategies_count; i += this->sub_strategies_count) {
+        for (int_fast32_t j = i + 1; j < i + this->sub_strategies_count; j++) {
+            this->strategies[i].points += this->strategies[j].points;
+            this->strategies[j].points = 0;
+        }
+        this->strategies[i].points /= this->sub_strategies_count;
+    }
+}
+
 static int_fast32_t find_min_strategy(Strategy_data* this) {
     uint_fast32_t min = INT_MAX;
     uint_fast32_t min_index;
     for (int_fast32_t i = 0; i < this->all_strategies_count; i += this->sub_strategies_count) {
-        uint_fast32_t points = this->strategies[i].points;
-        this->strategies[i].points = 0;
-
-        for (int_fast32_t j = i + 1; j < i + this->sub_strategies_count; j++) {
-            points += this->strategies[j].points;
-            this->strategies[j].points = 0;
-        }
-
-        points /= this->sub_strategies_count;
-        if(points < min) {
-            min = points;
+        if(this->strategies[i].points < min) {
+            min = this->strategies[i].points;
             min_index = i;
         }
-
-//        print_binary(this->strategies[i].name, this->main_digits_count);
-//        printf("\t%d\n", points);
+        this->strategies[i].points = 0;
     }
     return min_index;
 }

--- a/strategy.h
+++ b/strategy.h
@@ -6,7 +6,7 @@ typedef struct {
     uint_fast8_t name;
     uint_fast8_t sub_strategies;
     uint_fast8_t prev_move;
-    //uint_fast8_t first_move;
+    uint_fast8_t complexity;
     uint_fast64_t points;
 } Strategy;
 

--- a/strategy.h
+++ b/strategy.h
@@ -37,6 +37,15 @@ Strategy_data* create_Strategy_data(uint_fast32_t memory_depth, uint_fast32_t it
 void play(Strategy_data* this, int_fast32_t i, int_fast32_t j);
 
 /**
+* Function for averaging points of family of strategies with the same name
+* but different sub-strategies. Should be called before removing
+* @param this - object of Strategy_data with needed strategies and parameters
+*/
+void average_strategies(Strategy_data* this);
+
+/**
+* NOTE! call average_strategies() function first!!!
+*
 * Function for removing family of strategies with minimum points
 * @param this - object of Strategy_data with needed strategies and parameters
 */

--- a/strategy.h
+++ b/strategy.h
@@ -4,13 +4,15 @@
 
 typedef struct {
     uint_fast8_t name;
+    uint_fast8_t sub_strategies;
     uint_fast8_t prev_move;
-    uint_fast8_t first_move;
+    //uint_fast8_t first_move;
     uint_fast64_t points;
 } Strategy;
 
 typedef struct {
     int_fast32_t matrix[2][2];
+    int_fast32_t memory_depth;
     int_fast32_t iterations_count;
     int_fast32_t main_digits_count;
     int_fast32_t main_strategies_count;
@@ -42,6 +44,7 @@ void remove_strategies(Strategy_data* this);
 
 /**
 * Destructor of Strategy_data object. Frees all memory
+* @param this - object of Strategy_data to be freed
 */
 void delete_Strategy_data(Strategy_data* this);
 


### PR DESCRIPTION
Еще добавил файл memory.h с макросом для удобного выделения памяти - вместо маллока и тысячи скобок теперь можно писать просто new(int, 4) (первый параметр - имя типа, второй - сколько элементов создать). Если не массив, просто единицу. Макрос возвращает указатель на переданный тип, т.е. если вызвать new(int*, 1), то вернется int**. Освобождаем как и раньше через free. 